### PR TITLE
Disable auto-popup for AI-initiated trades

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -590,13 +590,6 @@ function App({ multiplayerConfig, initialGameState, onLeaveGame }: AppProps) {
   // Keep ref in sync with aiTradeProposal state (for use in effects)
   useEffect(() => { aiTradeProposalRef.current = aiTradeProposal; }, [aiTradeProposal]);
 
-  // Auto-open player trade modal when an AI trade proposal arrives
-  useEffect(() => {
-    if (aiTradeProposal) {
-      setPlayerTradeModalOpen(true);
-    }
-  }, [aiTradeProposal]);
-
   // Multiplayer: non-host clients detect AI trade proposals from synced game state
   useEffect(() => {
     if (!multiplayerConfig) return;


### PR DESCRIPTION
AI trade offers now only show a gold glow on the PLAYERS button instead
of automatically opening the trade modal. Players click the button when
they're ready to review the offer.

https://claude.ai/code/session_016qhezoBH1waJ12SyWDABaN