### PR TITLE
Fix biased array shuffle with Fisher-Yates algorithm

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -84,9 +84,17 @@ function posKey(x: number, y: number): string {
   return `${Math.round(x)},${Math.round(y)}`;
 }
 
+function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
 export function generateBoard(): { hexes: Hex[]; vertices: Vertex[]; edges: Edge[]; ports: Port[] } {
   // Shuffle the layout
-  const shuffled = [...BOARD_LAYOUT].sort(() => Math.random() - 0.5);
+  const shuffled = shuffle([...BOARD_LAYOUT]);
 
   // Create hexes
   const hexes: Hex[] = HEX_COORDS.map((coords, i) => ({

--- a/src/gameState.ts
+++ b/src/gameState.ts
@@ -20,11 +20,19 @@ export interface PlayerConfig {
   isHuman: boolean;
 }
 
+function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
 export function createInitialGameState(playerConfigs?: PlayerConfig[]): GameState {
   const { hexes, vertices, edges, ports } = generateBoard();
 
   // Shuffle dev cards
-  const shuffledDevCards = [...DEV_CARDS].sort(() => Math.random() - 0.5);
+  const shuffledDevCards = shuffle([...DEV_CARDS]);
 
   // Create players with starting resources
   const players: Player[] = [0, 1, 2, 3].map(i => ({


### PR DESCRIPTION
## Summary
- Replace biased `.sort(() => Math.random() - 0.5)` shuffle with Fisher-Yates (Knuth) shuffle in both `src/board.ts` (board tile shuffling) and `src/gameState.ts` (dev card deck shuffling)
- The sort-based approach produces non-uniform distributions because comparison sort algorithms expect a consistent comparator
- Added a local `shuffle<T>()` helper function in each file for correct uniform randomness

## Test plan
- [x] `npm run build` passes with no errors
- [ ] Verify board tile placement appears random across multiple game starts
- [ ] Verify dev card draw order appears random across multiple games

🤖 Generated with [Claude Code](https://claude.com/claude-code)