### PR TITLE
Fix robber discard threshold to match Catan rules

### DIFF
--- a/src/gameState.ts
+++ b/src/gameState.ts
@@ -393,10 +393,10 @@ export function updateLargestArmy(state: GameState): void {
   }
 }
 
-// Get players who need to discard (have 7+ cards)
+// Get players who need to discard (have more than 7 cards)
 export function getPlayersToDiscard(state: GameState): number[] {
   return state.players
-    .filter(p => getTotalResources(p) >= 7)
+    .filter(p => getTotalResources(p) > 7)
     .map(p => p.id);
 }
 


### PR DESCRIPTION
## Summary
- Fixed the discard threshold in `getPlayersToDiscard` from `>= 7` to `> 7`
- Per official Catan rules, players discard only when they have **more than 7** resource cards (8+), not 7 or more
- Players with exactly 7 cards were incorrectly forced to discard

## Test plan
- [ ] Verify that a player with exactly 7 resource cards is NOT prompted to discard when a 7 is rolled
- [ ] Verify that a player with 8+ resource cards IS prompted to discard when a 7 is rolled
- [ ] Run `npm run build` to confirm no build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)