### PR TITLE
Fix simple lint errors: prefer-const and unused eslint-disable

### DIFF
--- a/src/stats/statsService.ts
+++ b/src/stats/statsService.ts
@@ -29,7 +29,7 @@ export async function getUserStats(uid: string): Promise<UserStats | null> {
 export async function recordGameAndUpdateStats(
   uid: string, displayName: string, photoURL: string | null, record: GameRecord,
 ): Promise<UserStats> {
-  let stats = await getUserStats(uid) ?? createEmptyStats(uid, displayName, photoURL);
+  const stats = await getUserStats(uid) ?? createEmptyStats(uid, displayName, photoURL);
   stats.displayName = displayName;
   stats.photoURL = photoURL;
   stats.gamesPlayed++;

--- a/src/useGameRoom.ts
+++ b/src/useGameRoom.ts
@@ -101,7 +101,6 @@ export function useMultiplayerSync(
     }).catch((err: unknown) => {
       console.error('[useMultiplayerSync] write failed:', err);
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [game, roomId]);
 
   // Listener effect: receive remote updates


### PR DESCRIPTION
## Summary
- Change `let stats` to `const stats` in `src/stats/statsService.ts:32` — the variable is only mutated (property assignments), never reassigned
- Remove unused `// eslint-disable-next-line react-hooks/exhaustive-deps` comment in `src/useGameRoom.ts:104`

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` no longer reports `prefer-const` or unused eslint-disable errors
- Remaining lint errors/warnings are pre-existing and require larger refactors

🤖 Generated with [Claude Code](https://claude.com/claude-code)