### PR TITLE
[Dependencies] Patch protobufjs (critical) and vite (high) CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3657,9 +3657,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4041,9 +4041,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- `npm audit fix` resolves two advisories in the root workspace:
  - **protobufjs <7.5.5** — critical (GHSA-xq3m-2v4x-88gg, arbitrary code execution). Transitive via `firebase`, so it affects the production bundle.
  - **vite 7.0.0–7.3.1** — high (path traversal, `server.fs.deny` bypass, WebSocket arbitrary file read). Dev-only, but still worth patching.
- No breaking changes required; lockfile-only update, production build still succeeds.

## Test plan
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)